### PR TITLE
add Linus support (beyond OSX support)

### DIFF
--- a/hook-flow.sh
+++ b/hook-flow.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 # hook-flow
 
-open https://github.com/donavon/hook-flow
+#  open https://github.com/donavon/hook-flow
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     xdg-open https://github.com/donavon/hook-flow;;
+    Darwin*)    open https://github.com/donavon/hook-flow;;
+    CYGWIN*)    xdg-open https://github.com/donavon/hook-flow;;
+    MINGW*)     xdg-open https://github.com/donavon/hook-flow;;
+    *)          echo "machine UNKNOWN"
+esac


### PR DESCRIPTION
open command on Linux attempt to open a new terminal.  OSX uses open to view a image or a web page, Linux equivalent is xdg-open.

